### PR TITLE
extracted disqus id to yml config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,6 +15,7 @@ url: "http://spaghetti.ga" # the base hostname & protocol for your site
 twitter_username: axlyody
 github_username:  spaghetti-san
 facebook_username:  axlyody
+disqus_id: spaghettisan.disqus.com
 
 # Gems
 gems: 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -97,7 +97,7 @@ this.page.identifier = {{page.id}}; // Replace PAGE_IDENTIFIER with your page's 
 (function() { // DON'T EDIT BELOW THIS LINE
 var d = document, s = d.createElement('script');
 
-s.src = '//spaghettisan.disqus.com/embed.js';
+s.src = '//{{ site.disqus_id }}/embed.js';
 
 s.setAttribute('data-timestamp', +new Date());
 (d.head || d.body).appendChild(s);


### PR DESCRIPTION
I've been trying to enable comments and found out that comments from disqus are hardcoded to spaghetti.ga.

So, i've removed hardcode and replaced it with parameter in config
