### PR TITLE
Implement support for site.baseurl

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -42,12 +42,12 @@
 </footer>
 <!--- Where Javascript Loaded --->
 <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
-<script type="text/javascript" src="/assets/js/jquery-pjax.js"></script>
-<script type="text/javascript" src="/assets/js/jquery-preload.js"></script>
-<script type="text/javascript" src="/assets/js/jquery-tooltipster.js"></script>
+<script type="text/javascript" src="{{ "/assets/js/jquery-pjax.js" | prepend: site.baseurl }}"></script>
+<script type="text/javascript" src="{{ "/assets/js/jquery-preload.js" | prepend: site.baseurl }}"></script>
+<script type="text/javascript" src="{{ "/assets/js/jquery-tooltipster.js" | prepend: site.baseurl }}"></script>
 <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/pace/1.0.2/pace.min.js"></script>
-<script type="text/javascript" src="/assets/js/jquery-autocomplete.js"></script>
-<script type="text/javascript" src="/assets/js/responsive_waterfall.js"></script>
+<script type="text/javascript" src="{{ "/assets/js/jquery-autocomplete.js" | prepend: site.baseurl }}"></script>
+<script type="text/javascript" src="{{ "/assets/js/responsive_waterfall.js" | prepend: site.baseurl }}"></script>
 <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/jquery.lazyload/1.9.1/jquery.lazyload.min.js"></script>
 <script id="dsq-count-scr" src="//spaghettisan.disqus.com/count.js" async></script>
 <script>
@@ -79,7 +79,7 @@ $.preload({
     }, 2e3)
 });
 $(document).ready(function() {
-    "/" != location.pathname ? $('.trigger a[href^="/' + location.pathname.split("/")[1] + '"]').addClass("active") : $(".none a:eq(0)").addClass("active")
+    "{{site.baseurl}}/" != location.pathname ? $('.trigger a[href^="' + location.pathname + '"]').addClass("active") : $(".none a:eq(0)").addClass("active")
 }), $(document).ready(function() {
     $(".tooltip-right").tooltipster({
         contentAsHTML: !0,
@@ -101,7 +101,7 @@ $(document).ready(function() {
     $("img").lazyload({})
 });
 var options = {
-    url: "/gblk.json",
+    url: "{{ "/gblk.json" | prepend: site.baseurl }}",
     getValue: "title",
     list: {
         match: {

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -23,7 +23,7 @@
           {% endunless %}
           {% endif %}
         {% endfor %}
-        <a class="page-link" href="{{ site.url }}/feed.xml"> Feeds</a>
+        <a class="page-link" href="{{ site.url | append: site.baseurl }}/feed.xml"> Feeds</a>
         <a class="page-link" href="http://github.com/{{ site.github_username }}?tab=repositories"><i class="typico typcn typcn-social-github" style="font-size:"></i> Repositories</a>
       </div>
     </nav>

--- a/_includes/post-tags.html
+++ b/_includes/post-tags.html
@@ -4,5 +4,5 @@
     {% assign tags = page.tags %}
   {% endif %}
   {% for tag in tags %}
-  <a id="route" href="/tags.html#{{tag|slugize}}"> {{tag}}</a>{% unless forloop.last %} {% endunless %}
+  <a id="route" href="{{ "/tags.html#" | append: tag|slugize | prepend: site.baseurl }}"> {{tag}}</a>{% unless forloop.last %} {% endunless %}
   {% endfor %}

--- a/_includes/widgets.html
+++ b/_includes/widgets.html
@@ -14,7 +14,7 @@
 	  {% for tag in site.tags %}
 	  
   <li style="font-size: {{ tag | last | size | times: 100 | divided_by: site.tags.size | plus: 70  }}%">
-    <a id="route" href="/tags/#{{ tag | first | slugize }}">
+    <a id="route" href="{{ "/tags/#" | prepend: site.baseurl }}{{ tag | first | slugize }}">
       {{ tag | first }}
       <span>{{ tag | last | size }}</span>
     </a>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -37,7 +37,7 @@ layout: default
  
 {% if page.next.url %} 
 <div class="arrowLeft">
-<a id="route" class="tooltip-right" href="{{page.next.url}}" title="
+<a id="route" class="tooltip-right" href="{{page.next.url | prepend: site.baseurl}}" title="
 &lt;p class=hoveratas&gt;{{page.next.title}}&lt;/p&gt; &lt;p class=hoverbawah&gt;{{ page.next.content | strip_html | truncatewords:10}}&lt;/p&gt;
 "><i class="typcn typcn-chevron-left" style="    font-size: 30px;
     position: relative;
@@ -48,7 +48,7 @@ layout: default
 
 {% if page.previous.url %} 
 <div class="arrowRight" style="float:right">
-<a id="route" class="tooltip-left" href="{{page.previous.url}}" title="
+<a id="route" class="tooltip-left" href="{{page.previous.url | prepend: site.baseurl}}" title="
 &lt;p class=hoveratas&gt;{{page.previous.title}}&lt;/p&gt; &lt;p class=hoverbawah&gt;{{ page.previous.content | strip_html | truncatewords:10}}&lt;/p&gt;
 "><i class="typcn typcn-chevron-right" style="    font-size: 30px;
     position: relative;

--- a/assets/css/alternative.css
+++ b/assets/css/alternative.css
@@ -20,7 +20,7 @@ figure {
 
 @font-face {
     font-family: gidole;
-    src: url(/assets/font/gidole.otf);
+    src: url(../font/gidole.otf);
 }
 
 body {

--- a/gblk.json
+++ b/gblk.json
@@ -2,6 +2,6 @@
     layout: null
 ---
 [
-  {% for post in site.posts %}{"title":"{{ post.title }}", "url":"{{ post.url }}"}{% if forloop.last %}{% else %},
+  {% for post in site.posts %}{"title":"{{ post.title }}", "url":"{{ post.url | prepend: site.baseurl }}"}{% if forloop.last %}{% else %},
   {% endif %}{% endfor %}
 ]

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@ layout: default
   <!-- Pagination links -->
 <div class="pagination">
   {% if paginator.previous_page %}
-    <a id="route" href="{{ paginator.previous_page_path }}" class="previous"><i class="typcn typcn-chevron-left-outline" style="    font-size: 14px;
+    <a id="route" href="{{ paginator.previous_page_path | prepend: site.baseurl }}" class="previous"><i class="typcn typcn-chevron-left-outline" style="    font-size: 14px;
     position: relative;
    
     "></i> Previous</a>
@@ -61,7 +61,7 @@ layout: default
   {% endif %}
   
   {% if paginator.next_page %}
-    <a id="route" href="{{ paginator.next_page_path }}" class="next">Next <i class="typcn typcn-chevron-right-outline" style="    font-size: 14px;
+    <a id="route" href="{{ paginator.next_page_path | prepend: site.baseurl }}" class="next">Next <i class="typcn typcn-chevron-right-outline" style="    font-size: 14px;
     position: relative;
   
     "></i></a>

--- a/tags.html
+++ b/tags.html
@@ -27,7 +27,7 @@ exclude_from_nav: true
     <a name="{{ tag_name | slugize }}"></a>
     {% for post in site.tags[tag_name] %}
     <article class="archive-item">
-      <p><h4><a href="{{ root_url }}{{ post.url }}">{{post.title}}</a></h4></p>
+      <p><h4><a href="{{ root_url }}{{ post.url | prepend: site.baseurl }}">{{post.title}}</a></h4></p>
       <p class="tags-date">{{ post.date | date: "%b %-d, %Y" }}</p>
     </article>
     {% endfor %}


### PR DESCRIPTION
The theme currently causes broken links to be served if `baseurl` is set in _config.yml_, i.e. if the blog is served from a subdirectory of the web root. This patch causes `site.baseurl` to be automatically prepended to URLs if necessary.
